### PR TITLE
Fix missing import for ProfileScreen

### DIFF
--- a/Nirvana/app/src/main/java/com/nirvana/ui/screens/ProfileScreen.kt
+++ b/Nirvana/app/src/main/java/com/nirvana/ui/screens/ProfileScreen.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigate
 import androidx.compose.runtime.Composable
+import com.google.firebase.ktx.Firebase
 
 @Composable
 fun ProfileScreen(navController: NavHostController) {


### PR DESCRIPTION
## Summary
- add `com.google.firebase.ktx.Firebase` import required for `Firebase.auth`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fa9586888324a523a5f8c8d752db