### PR TITLE
Configure JDK 17 for Nirvana build

### DIFF
--- a/Nirvana/README.md
+++ b/Nirvana/README.md
@@ -4,7 +4,14 @@ This repository contains the Nirvana Android application built with Jetpack Comp
 
 ## Building the project
 
-The project uses the Gradle wrapper. Ensure JDK 17 is installed and run:
+The project uses the Gradle wrapper. Ensure JDK 17 is installed and set the
+`JAVA_HOME` environment variable to its location, for example:
+
+```bash
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+```
+
+Then run:
 
 ```bash
 cd Nirvana
@@ -15,7 +22,7 @@ The resulting APK can be found under `Nirvana/app/build/outputs/apk/debug/`.
 
 ## Requirements
 
-- JDK 17
+- JDK 17 (set `JAVA_HOME` to the JDK path)
 - Android SDK with API level 34
 - Gradle 8
 

--- a/Nirvana/gradle.properties
+++ b/Nirvana/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64


### PR DESCRIPTION
## Summary
- set `org.gradle.java.home` in `gradle.properties`
- document JDK 17 and `JAVA_HOME` in the README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fa8dac3883249de2ecb2c03c4a23