### PR TITLE
Fix splash screen navigation

### DIFF
--- a/Nirvana/app/src/main/java/com/nirvana/ui/screens/SplashScreen.kt
+++ b/Nirvana/app/src/main/java/com/nirvana/ui/screens/SplashScreen.kt
@@ -29,7 +29,7 @@ fun SplashScreen(navController: NavHostController) {
         delay(500)
         opacity = 1f
         delay(2500)
-        navController.navigate("auth") {
+        navController.navigate("login") {
             popUpTo("splash") { inclusive = true }
         }
     }


### PR DESCRIPTION
## Summary
- switch splash navigation target from `auth` to `login`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fa92d5848324ab5e1c2976f2aae2